### PR TITLE
Check formChangedCallbacks is not undefined

### DIFF
--- a/scripts/TogglButtonForm.ts
+++ b/scripts/TogglButtonForm.ts
@@ -305,7 +305,9 @@ class TogglButtonForm {
     };
 
     onFormChanged(callback) {
-        this.formChangedCallbacks.push(callback);
+        if (this.formChangedCallbacks) {
+            this.formChangedCallbacks.push(callback);
+        }
 
     };
 }


### PR DESCRIPTION
before attempting to push in to it

I've had this happen after opening the Toggl window, closing it and then reopening it again.  The `onFormChanged` method is called but `formChangedCallbacks` is undefined.
Screenshot
![toggl](https://cloud.githubusercontent.com/assets/1314477/11617930/9c03de68-9ce0-11e5-8a17-2e74ddb40bd0.png)

What I can't immediately see is why this happens although I haven't dug into things too deeply.  Having the function as a prototype function, rather than using the fat-arrow syntax in TypeScript, could be part of it, since the "this" handling isn't done for you.  But in the code I provided I can see `this` is a TogglButtonForm as you'd expect.

Anyway, it's a small fairly harmless change but may be masking a bigger issue.

Note: I haven't updated any TypeScript output files.

Thanks for this extension!!